### PR TITLE
NMS-7799: Fix failed build with reports definition

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/sonicwall.graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/sonicwall.graph.properties
@@ -6,10 +6,8 @@
 ##################################################
 
 reports=sonicwall.CurrentCpuUtil, \
-reports=sonicwall.CurrentRamUtil, \
-reports=sonicwall.ConnCachEntry
-
-
+sonicwall.CurrentRamUtil, \
+sonicwall.ConnCachEntry
 
 report.sonicwall.CurrentCpuUtil.name=Sonicwall CPU Utilization
 report.sonicwall.CurrentCpuUtil.columns=sonicCurrentCPUUtil
@@ -47,7 +45,6 @@ report.sonicwall.CurrentCpuUtil.command=--title="Sonicwall CPU Utilization" \
  GPRINT:dpercent:AVERAGE:"Avg \\: %7.3lf%s" \
  GPRINT:dpercent:MIN:"Min \\: %7.3lf%s" \
  GPRINT:dpercent:MAX:"Max \\: %7.3lf%s\\n"
-
 
 report.sonicwall.CurrentRamUtil.name=Sonicwall Memory Utilization
 report.sonicwall.CurrentRamUtil.columns=sonicCurrentRAMUtil


### PR DESCRIPTION
Removed duplicated reports definition and removed unnecessary empty lines. Fix failed build for http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS85-1